### PR TITLE
Fixes animation issue where the pull to refresh header would get out of place.

### DIFF
--- a/ElasticPullToRefresh.podspec
+++ b/ElasticPullToRefresh.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "ElasticPullToRefresh"
-  s.version      = "1.3"
+  s.version      = "1.3.1"
   s.summary      = "A pull to refresh control that has a simple, elegant spinner"
   s.homepage     = "https://github.com/joshpc/ElasticPullToRefresh"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
   s.author       = { "Joshua Tessier" => "joshpc@gmail.com" }
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/joshpc/ElasticPullToRefresh.git", :tag => '1.3' }
+  s.source       = { :git => "https://github.com/joshpc/ElasticPullToRefresh.git", :tag => '1.3.1' }
   s.source_files = "ElasticPullToRefresh"
 end

--- a/ElasticPullToRefresh/ElasticPullToRefresh.swift
+++ b/ElasticPullToRefresh/ElasticPullToRefresh.swift
@@ -132,10 +132,11 @@ public class ElasticPullToRefresh: UIView, UIGestureRecognizerDelegate {
 	
 	private func updateContentInsets(insets: UIEdgeInsets) {
 		scrollView.removeObserver(self, forKeyPath: "contentInset")
-		UIView.animateWithDuration(animationDuration) { () -> Void in
+		UIView.animateWithDuration(animationDuration, animations: { () -> Void in
 			self.scrollView.contentInset = insets
+		}) { (completed: Bool) -> Void in
+			self.scrollView.addObserver(self, forKeyPath: "contentInset", options: .New, context: &self.context)
 		}
-		scrollView.addObserver(self, forKeyPath: "contentInset", options: .New, context: &context)
 	}
 	
 	private func handleScroll() {

--- a/SampleProject/ElasticPullToRefreshDemo/AppDelegate.swift
+++ b/SampleProject/ElasticPullToRefreshDemo/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	
 	func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 		window = UIWindow(frame: UIScreen.mainScreen().bounds)
-		window?.rootViewController = UINavigationController(rootViewController: ViewController())
+		window?.rootViewController = NavigationController(rootViewController: ViewController())
 		window?.makeKeyAndVisible()
 		
 		return true

--- a/SampleProject/ElasticPullToRefreshDemo/ViewController.swift
+++ b/SampleProject/ElasticPullToRefreshDemo/ViewController.swift
@@ -13,13 +13,29 @@ class ViewController: UIViewController {
 		let tableView = UITableView()
 		let wrapper = ElasticPullToRefresh(scrollView: tableView)
 		wrapper.didPullToRefresh = {
-			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(5 * NSEC_PER_SEC)), dispatch_get_main_queue()) { () -> Void in
+			dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(2 * NSEC_PER_SEC)), dispatch_get_main_queue()) { () -> Void in
 				wrapper.didFinishRefreshing()
 			}
 		}
 		view = wrapper
 	}
 	
+	override func viewWillAppear(animated: Bool) {
+		super.viewWillAppear(animated)
+		
+		self.navigationItem.title = "Bananas"
+		self.navigationController?.navigationBar.titleTextAttributes = [
+			NSForegroundColorAttributeName : UIColor.whiteColor(),
+			NSFontAttributeName : UIFont.systemFontOfSize(18.0, weight: UIFontWeightBold)
+		];
+		self.navigationController?.navigationBar.translucent = false
+		self.navigationController?.navigationBar.shadowImage = UIImage()
+		self.navigationController?.navigationBar.setBackgroundImage(UIImage(), forBarMetrics: .Default)
+		self.navigationController?.navigationBar.barTintColor = UIColor.purpleColor()
+	}
+}
+
+class NavigationController: UINavigationController {
 	override func preferredStatusBarStyle() -> UIStatusBarStyle {
 		return .LightContent
 	}


### PR DESCRIPTION
## What this does
1. Fixes animation issue
2. Bumps pod version
3. Updates demo app to be closer to the gif

When pulling the table view, we properly position the pull to refresh header so that it seems as if it's being pulled out of the navigation bar. However, when it's animating down, it gets into a state where the shape of the view will not change as the animation is still in progress. Therefore we only begin observing the contentInset changes again once the animation is done, avoiding the problem all together.
